### PR TITLE
Alternate Rcpp:List constructor for long lists

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -6,7 +6,7 @@
 #' @param demp list of demographic input parameters (TODO: document)
 #' @param projp list of HIV projection parameters (TODO: document)
 #' @param hiv_strat stratification of HIV population, either "full"
-#'   (default; single-year ages) or "coarse" (aggregated age groups). 
+#'   (default; single-year ages) or "coarse" (aggregated age groups).
 #' @param hiv_steps_per_year number of Euler integration steps per year
 #'   for HIV progression; default 10.
 #'
@@ -15,7 +15,7 @@
 #' to apply to the base year population (consistent with Spectrum).
 #'
 #' @export
-#' 
+#'
 leapfrogR <- function(demp, projp, hiv_strat = "full", hiv_steps_per_year = 10L) {
     .Call(`_leapfrog_leapfrogR`, demp, projp, hiv_strat, hiv_steps_per_year)
 }

--- a/src/ListBuilder.h
+++ b/src/ListBuilder.h
@@ -1,0 +1,68 @@
+// ListBuilder class copied from Kevin Ushey comment on Github issue:
+// https://github.com/RcppCore/Rcpp/issues/243#issuecomment-73378636
+
+// Usage example:
+//
+// // [[Rcpp::export]]
+// List test_builder(SEXP x, SEXP y, SEXP z, std::string w) {
+//   return ListBuilder()
+//     .add("foo", x)
+//     .add("bar", y)
+//     .add("baz", z)
+//     .add("bat", w);
+// }
+//
+// /*** R
+// test_builder(1:5, letters[1:5], rnorm(5), "abc")
+// */
+
+#include <Rcpp.h>
+using namespace Rcpp;
+
+class ListBuilder {
+
+public:
+
+  ListBuilder() {};
+  ~ListBuilder() {};
+
+  inline ListBuilder& add(const std::string& name, SEXP x) {
+    names.push_back(name);
+    elements.push_back(PROTECT(x));
+    return *this;
+  }
+
+  template <typename T>
+  inline ListBuilder& add(const std::string& name, const T& x) {
+    names.push_back(name);
+    elements.push_back(PROTECT(wrap(x)));
+    return *this;
+  }
+
+  inline operator List() const {
+    List result(elements.size());
+    for (size_t i = 0; i < elements.size(); ++i) {
+      result[i] = elements[i];
+    }
+    result.attr("names") = wrap(names);
+    UNPROTECT(elements.size());
+    return result;
+  }
+
+  inline operator DataFrame() const {
+    List result = static_cast<List>(*this);
+    result.attr("class") = "data.frame";
+    result.attr("row.names") = IntegerVector::create(NA_INTEGER, XLENGTH(elements[0]));
+    return result;
+  }
+
+private:
+
+  std::vector<std::string> names;
+  std::vector<SEXP> elements;
+
+  ListBuilder(ListBuilder const&) {};
+
+};
+
+

--- a/src/leapfrogR.cpp
+++ b/src/leapfrogR.cpp
@@ -1,6 +1,7 @@
 #include <Rcpp.h>
 
 #include "leapfrog-raw.h"
+#include "ListBuilder.h" // alternative for construct lists longer than 20 elements
 
 //' Simulate leapfrog model
 //'
@@ -250,27 +251,28 @@ leapfrogR(const Rcpp::List& demp,
     Rf_error("Invalid HIV stratification age groups (hAG)");
   }
 
-  List ret = List::create( _("totpop1") = totpop1,
-			  _("hivpop1") = hivpop1,
-			  _("hivnpop1") = hivnpop1,
-			  _("hivstrat_adult") = hivstrat_adult,
-			  _("artstrat_adult") = artstrat_adult,
-			  _("hivstrat_paeds") = hivstrat_paeds,
-			  _("artstrat_paeds") = artstrat_paeds,
-			  _("artelig_paeds") = artelig_paeds,
-			  _("infections") = infections,
-			  _("births") = births,	
-			  _("hiv_births") = hiv_births,			  
-			  _("natdeaths") = natdeaths,
-			  _("natdeaths_hivpop") = natdeaths_hivpop,
-			  _("hivdeaths") = hivdeaths,
-			  _("aidsdeaths_noart") = aidsdeaths_noart,
-			  _("aidsdeaths_art") = aidsdeaths_art,
-			  _("aidsdeaths_noart_paed") = aidsdeaths_noart_paed,
-			  _("aidsdeaths_art_paed") = aidsdeaths_art_paed,
-			  _("artnum_paed") = artnum_paed,
-			  _("artinit") = artinit,
-			  _("coarse_totpop1") = coarse_totpop1);
+  List ret = ListBuilder()
+    .add("totpop1", totpop1)
+    .add("hivpop1", hivpop1)
+    .add("hivnpop1", hivnpop1)
+    .add("hivstrat_adult", hivstrat_adult)
+    .add("artstrat_adult", artstrat_adult)
+    .add("hivstrat_paeds", hivstrat_paeds)
+    .add("artstrat_paeds", artstrat_paeds)
+    .add("artelig_paeds", artelig_paeds)
+    .add("infections", infections)
+    .add("births", births)
+    .add("hiv_births", hiv_births)
+    .add("natdeaths", natdeaths)
+    .add("natdeaths_hivpop", natdeaths_hivpop)
+    .add("hivdeaths", hivdeaths)
+    .add("aidsdeaths_noart", aidsdeaths_noart)
+    .add("aidsdeaths_art", aidsdeaths_art)
+    .add("aidsdeaths_noart_paed", aidsdeaths_noart_paed)
+    .add("aidsdeaths_art_paed", aidsdeaths_art_paed)
+    .add("artnum_paed", artnum_paed)
+    .add("artinit", artinit)
+    .add("coarse_totpop1", coarse_totpop1);
 
   return ret;
 }

--- a/src/leapfrogR.cpp
+++ b/src/leapfrogR.cpp
@@ -41,7 +41,7 @@ leapfrogR(const Rcpp::List& demp,
   const int trans = 4;
   const int tx_time = 3;
   const int hTS = 3;
-  const int ctx_effect = 0.33;
+  const double ctx_effect = 0.33;
 
   int hAG;
   if (hiv_strat == "full") {


### PR DESCRIPTION
This uses an alternate constructor posted on Github issue by Kevin Usher (thanks!!): 
 https://github.com/RcppCore/Rcpp/issues/243#issuecomment-73378636

I also noticed that `ctx_effect` had been declared as an `int`. This should be a double I think: `const double ctx_effect = 0.33;`. Have fixed that in the PR.

It compiles now, but when I tried to test running, I got an error (I think a missing file in the pushed branch):

```
> hivp <- prepare_leapfrog_projp(pjnz)
Error in file(file, "rt") : cannot open the connection
In addition: Warning message:
In file(file, "rt") :
  cannot open file 'tests/testdata/spectrum/v6.13/paed_art_dist.csv': No such file or directory
```

So leaving for you to test :smile:.

In reviewing the code, I noticed a couple of other things interested to discuss:

* Not clear to me what new argument `trans` means.
* Curious why `hivnpop1` needs an output.


