### PR TITLE
fix child ART percent flag

### DIFF
--- a/R/read-spectrum.R
+++ b/R/read-spectrum.R
@@ -316,7 +316,7 @@ dp_read_childart <- function(dp) {
     stop("Child ART input tag not recognized. Function probably needs update for this .DP file.")
   }
 
-  childart_ispercent <- sapply(childart_ispercent, as.logical)
+  childart_ispercent <- sapply(childart_ispercent, as.numeric) == 1
   dimnames(childart_ispercent) <- list(indicator = indicator_names, year = dpy$proj_years)
 
   list(childart = childart,


### PR DESCRIPTION
In function `dp_read_childart()`, error in code to convert 'is percentage' 0/1 values to logical. They were being read as strings (`"0"` or `"1"`) which `as.logical()` was converting to `NA`.

Coerce them to numeric, then check `==1` to convert to logical.